### PR TITLE
Disable single_line_throw rule

### DIFF
--- a/src/Php56.php
+++ b/src/Php56.php
@@ -18,6 +18,7 @@ final class Php56 extends Config
             'array_syntax' => [
                 'syntax' => 'short',
             ],
+            'single_line_throw' => false
         ];
 
         return $rules;

--- a/src/Php72.php
+++ b/src/Php72.php
@@ -18,6 +18,7 @@ final class Php72 extends Config
             'array_syntax' => [
                 'syntax' => 'short',
             ],
+            'single_line_throw' => false
         ];
 
         return $rules;


### PR DESCRIPTION
Added in last version of php-cs-fixer for `@Symfony` rules